### PR TITLE
fix: avoid synthetic activity end times

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ Primary user docs and examples live in `README.md`.
   - Read full GPX from stdin, write resulting GPX to stdout; print errors to stderr, exit non-zero on failure.
   - Avoid interactive prompts; be scriptable.
 - Time ranges are relative to the earliest track point timestamp.
-- Range semantics are inclusive of start and exclusive of end: [start, end).
+- Manual trim ranges are inclusive of start and exclusive of end: [start, end).
+- Activity trimming treats the detected final activity point as included; do not fake that by creating a synthetic
+  timestamp just past the final point.
 - Preserve GPX structure and unknown extensions for any kept `trkpt`.
 - Prefer streaming processing for XML (no full DOM); `extract_track_points` returns an in-memory list only when required by algorithms (e.g., activity detection).
 
@@ -36,7 +38,7 @@ Primary user docs and examples live in `README.md`.
   - Internally: parse with `parse_range`, read earliest time via `find_minimum_time`, then filter with `filter_xml_by_time_range`.
 - `trim-to-activity [-s, --speed-threshold <m/s>] [-b, --buffer <seconds>]`
   - Detects the main activity window via speeds between consecutive track points.
-  - Internals: `extract_track_points` → `detect_activity_bounds` → `filter_xml_by_time_range`.
+  - Internals: `extract_track_points` → `detect_activity_bounds` → `filter_xml_by_time_range_inclusive_end`.
   - Defaults: speed threshold 1.0 m/s, buffer 30 s; requires at least two timestamped points.
 
 ### Key modules and functions

--- a/src/commands/trim_to_activity.rs
+++ b/src/commands/trim_to_activity.rs
@@ -1,4 +1,4 @@
-use crate::gpxxml::{extract_track_points, filter_xml_by_time_range};
+use crate::gpxxml::{extract_track_points, filter_xml_by_time_range_inclusive_end};
 use gpxwrench::detect_activity_bounds;
 use std::error::Error;
 use std::io::{self, Read, Write};
@@ -17,6 +17,6 @@ pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(),
 
     let (start_time, end_time) = detect_activity_bounds(&track_points, speed_threshold, buffer)?;
 
-    filter_xml_by_time_range(&input, start_time, end_time)?;
+    filter_xml_by_time_range_inclusive_end(&input, start_time, end_time)?;
     Ok(())
 }

--- a/src/gpxxml.rs
+++ b/src/gpxxml.rs
@@ -84,10 +84,34 @@ pub fn filter_xml_by_time_range(
     )
 }
 
+pub fn filter_xml_by_time_range_inclusive_end(
+    input: &[u8],
+    start_threshold: OffsetDateTime,
+    end_threshold: OffsetDateTime,
+) -> Result<(), Box<dyn Error>> {
+    filter_xml_by_time_to_writer_with_end_mode(
+        input,
+        start_threshold,
+        Some(end_threshold),
+        true,
+        std::io::stdout(),
+    )
+}
+
 pub fn filter_xml_by_time_to_writer<W: Write>(
     input: &[u8],
     start_threshold: OffsetDateTime,
     end_threshold: Option<OffsetDateTime>,
+    output: W,
+) -> Result<(), Box<dyn Error>> {
+    filter_xml_by_time_to_writer_with_end_mode(input, start_threshold, end_threshold, false, output)
+}
+
+fn filter_xml_by_time_to_writer_with_end_mode<W: Write>(
+    input: &[u8],
+    start_threshold: OffsetDateTime,
+    end_threshold: Option<OffsetDateTime>,
+    include_end_threshold: bool,
     output: W,
 ) -> Result<(), Box<dyn Error>> {
     let mut reader = Reader::from_reader(input);
@@ -146,7 +170,12 @@ pub fn filter_xml_by_time_to_writer<W: Write>(
                     // Decide whether to include this trkpt based on time range
                     let include_point = if let Some(point_time) = trkpt_time {
                         if let Some(end_thresh) = end_threshold {
-                            point_time >= start_threshold && point_time < end_thresh
+                            point_time >= start_threshold
+                                && if include_end_threshold {
+                                    point_time <= end_thresh
+                                } else {
+                                    point_time < end_thresh
+                                }
                         } else {
                             point_time <= start_threshold
                         }
@@ -468,6 +497,27 @@ mod tests {
         // Verify the times are correct
         assert!(points[0].time.is_some());
         assert!(points[1].time.is_some());
+    }
+
+    #[test]
+    fn test_filter_xml_by_time_range_inclusive_end() {
+        use gpx::{Gpx, read};
+
+        let start_threshold = parse_timestamp("2023-01-01T10:00:00Z");
+        let end_threshold = parse_timestamp("2023-01-01T10:00:02Z");
+
+        let mut output = Vec::new();
+        filter_xml_by_time_to_writer_with_end_mode(
+            SAMPLE_GPX.as_bytes(),
+            start_threshold,
+            Some(end_threshold),
+            true,
+            &mut output,
+        )
+        .unwrap();
+
+        let gpx: Gpx = read(output.as_slice()).unwrap();
+        assert_eq!(gpx.tracks[0].segments[0].points.len(), 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,9 +160,17 @@ pub fn detect_activity_bounds(
     let start_idx = activity_start_idx.unwrap_or(0);
     let end_idx = activity_end_idx.unwrap_or(track_points.len() - 1);
 
-    let buffer_duration = Duration::seconds(buffer_seconds as i64);
-    let start_time = track_points[start_idx].time - buffer_duration;
-    let end_time = track_points[end_idx].time + buffer_duration;
+    let buffer_seconds = i64::try_from(buffer_seconds)
+        .map_err(|_| "Buffer seconds exceed supported duration range")?;
+    let buffer_duration = Duration::seconds(buffer_seconds);
+    let start_time = track_points[start_idx]
+        .time
+        .checked_sub(buffer_duration)
+        .ok_or("Activity start time exceeds supported timestamp range")?;
+    let end_time = track_points[end_idx]
+        .time
+        .checked_add(buffer_duration)
+        .ok_or("Activity end time exceeds supported timestamp range")?;
 
     Ok((start_time, end_time))
 }
@@ -390,7 +398,8 @@ mod tests {
         assert!(result.is_ok());
         let (start, end) = result.unwrap();
 
-        // When all points are active, both start and end should be within the data range
+        // The activity detector returns selected point times; the XML writer decides
+        // whether the end bound is inclusive for a given command.
         assert!(start >= points[0].time, "Start should be within data range");
         assert!(
             end <= points[points.len() - 1].time,
@@ -476,7 +485,6 @@ mod tests {
         assert!(result.is_ok());
         let (start, end) = result.unwrap();
 
-        // Should successfully detect activity and return valid bounds
         assert!(start >= points[0].time, "Start should be within data range");
         assert!(
             start <= points[points.len() - 1].time,
@@ -541,12 +549,107 @@ mod tests {
         let end_diff = (result_with_buffer.1 - result_no_buffer.1).whole_seconds();
         assert_eq!(start_diff, 10, "Start buffer should be 10 seconds");
         assert_eq!(end_diff, 10, "End buffer should be 10 seconds");
+        assert_eq!(result_with_buffer.1, points[5].time + Duration::seconds(10));
     }
 
     #[test]
     fn test_detect_activity_bounds_empty() {
         let points: Vec<TrackPoint> = vec![];
         let result = detect_activity_bounds(&points, 5.0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_activity_bounds_rejects_oversized_buffer() {
+        let points = vec![
+            make_track_point(37.7749, -122.4194, "2023-01-01T10:00:00Z"),
+            make_track_point(37.7759, -122.4194, "2023-01-01T10:00:05Z"),
+        ];
+
+        let result = detect_activity_bounds(&points, 5.0, u64::MAX);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_activity_bounds_rejects_start_time_underflow() {
+        let points = vec![
+            make_track_point(37.7749, -122.4194, "2023-01-01T10:00:00Z"),
+            make_track_point(37.7759, -122.4194, "2023-01-01T10:00:05Z"),
+        ];
+
+        let result = detect_activity_bounds(&points, 5.0, i64::MAX as u64);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_detect_activity_bounds_allows_max_end_time_without_buffer() {
+        let final_time = OffsetDateTime::parse(
+            "9999-12-31T23:59:59.999999999Z",
+            &time::format_description::well_known::Iso8601::DEFAULT,
+        )
+        .unwrap();
+        let points = vec![
+            TrackPoint {
+                lat: 37.7749,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(15),
+            },
+            TrackPoint {
+                lat: 37.7759,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(10),
+            },
+            TrackPoint {
+                lat: 37.7769,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(5),
+            },
+            TrackPoint {
+                lat: 37.7779,
+                lon: -122.4194,
+                time: final_time,
+            },
+        ];
+
+        let result = detect_activity_bounds(&points, 5.0, 0);
+
+        assert_eq!(result.unwrap().1, final_time);
+    }
+
+    #[test]
+    fn test_detect_activity_bounds_rejects_end_time_overflow_with_buffer() {
+        let final_time = OffsetDateTime::parse(
+            "9999-12-31T23:59:59.999999999Z",
+            &time::format_description::well_known::Iso8601::DEFAULT,
+        )
+        .unwrap();
+        let points = vec![
+            TrackPoint {
+                lat: 37.7749,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(15),
+            },
+            TrackPoint {
+                lat: 37.7759,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(10),
+            },
+            TrackPoint {
+                lat: 37.7769,
+                lon: -122.4194,
+                time: final_time - Duration::seconds(5),
+            },
+            TrackPoint {
+                lat: 37.7779,
+                lon: -122.4194,
+                time: final_time,
+            },
+        ];
+
+        let result = detect_activity_bounds(&points, 5.0, 1);
+
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
Activity detection can select a final point at the maximum representable timestamp. Adding one nanosecond to adapt that to an exclusive filter turns that valid case into an overflow.

This keeps the detector's bounds as actual point timestamps and moves end-inclusion into the XML filtering mode used by `trim-to-activity`.
