### PR TITLE
fix: reject overflowing trim ranges

### DIFF
--- a/src/commands/trim.rs
+++ b/src/commands/trim.rs
@@ -14,8 +14,22 @@ pub fn trim_command(range_str: &str) -> Result<(), Box<dyn Error>> {
 
     if let Some(min_t) = min_time {
         let (start_threshold, end_threshold) = match range {
-            TrimRange::Duration { start, end } => (min_t + start, min_t + end),
-            TrimRange::Timestamp { start, end } => (min_t + start, min_t + end),
+            TrimRange::Duration { start, end } => (
+                min_t
+                    .checked_add(start)
+                    .ok_or("Trim start exceeds supported timestamp range")?,
+                min_t
+                    .checked_add(end)
+                    .ok_or("Trim end exceeds supported timestamp range")?,
+            ),
+            TrimRange::Timestamp { start, end } => (
+                min_t
+                    .checked_add(start)
+                    .ok_or("Trim start exceeds supported timestamp range")?,
+                min_t
+                    .checked_add(end)
+                    .ok_or("Trim end exceeds supported timestamp range")?,
+            ),
         };
 
         filter_xml_by_time_range(&input, start_threshold, end_threshold)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,15 @@ pub fn parse_duration(s: &str) -> Result<Duration, Box<dyn Error>> {
     let (num_str, unit) = s.split_at(s.len() - 1);
     let num: i64 = num_str.parse()?;
 
-    match unit {
-        "s" => Ok(Duration::seconds(num)),
-        "m" => Ok(Duration::minutes(num)),
-        "h" => Ok(Duration::hours(num)),
-        _ => Err(format!("Invalid duration unit: {unit}").into()),
+    let seconds = match unit {
+        "s" => Some(num),
+        "m" => num.checked_mul(60),
+        "h" => num.checked_mul(60 * 60),
+        _ => return Err(format!("Invalid duration unit: {unit}").into()),
     }
+    .ok_or("Duration exceeds supported range")?;
+
+    Ok(Duration::seconds(seconds))
 }
 
 pub fn parse_timestamp(s: &str) -> Result<Duration, Box<dyn Error>> {
@@ -43,7 +46,18 @@ pub fn parse_timestamp(s: &str) -> Result<Duration, Box<dyn Error>> {
         _ => return Err("Invalid timestamp format".into()),
     };
 
-    Ok(Duration::hours(hours) + Duration::minutes(minutes) + Duration::seconds(seconds))
+    let hours = hours
+        .checked_mul(60 * 60)
+        .ok_or("Timestamp hour value exceeds supported duration range")?;
+    let minutes = minutes
+        .checked_mul(60)
+        .ok_or("Timestamp minute value exceeds supported duration range")?;
+    let total_seconds = hours
+        .checked_add(minutes)
+        .and_then(|total| total.checked_add(seconds))
+        .ok_or("Timestamp exceeds supported duration range")?;
+
+    Ok(Duration::seconds(total_seconds))
 }
 
 pub fn parse_range(range_str: &str) -> Result<TrimRange, Box<dyn Error>> {
@@ -199,6 +213,7 @@ mod tests {
         assert_eq!(parse_duration("2h").unwrap(), Duration::hours(2));
         assert!(parse_duration("5x").is_err());
         assert!(parse_duration("").is_err());
+        assert!(parse_duration("9223372036854775807h").is_err());
     }
 
     #[test]
@@ -214,6 +229,8 @@ mod tests {
         );
         assert!(parse_timestamp("1:2:3:4").is_err());
         assert!(parse_timestamp("invalid").is_err());
+        assert!(parse_timestamp("9223372036854775807:00:00").is_err());
+        assert!(parse_timestamp("2562047788015215:31:00").is_err());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,6 +175,50 @@ fn test_trim_invalid_range_fails() {
 }
 
 #[test]
+fn test_trim_timestamp_overflow_fails() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>9999-12-31T23:59:59.999999999Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    cmd.arg("trim")
+        .arg("1s,2s")
+        .write_stdin(gpx)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Trim start exceeds"));
+}
+
+#[test]
+fn test_trim_end_timestamp_overflow_fails() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>9999-12-31T23:59:58.999999999Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    cmd.arg("trim")
+        .arg("0s,2s")
+        .write_stdin(gpx)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Trim end exceeds"));
+}
+
+#[test]
 fn test_trim_command_preserves_gpx_structure() {
     let mut cmd = cargo_bin_cmd!("gpxwrench");
     let output = cmd


### PR DESCRIPTION
Trim range text is user-controlled input. Overflow during duration parsing or timestamp threshold calculation should report an error instead of panicking the process.
