### PR TITLE
fix: trim tracks without valid times

### DIFF
--- a/src/commands/trim.rs
+++ b/src/commands/trim.rs
@@ -1,7 +1,8 @@
 use crate::gpxxml::{filter_xml_by_time_range, find_minimum_time};
 use gpxwrench::{TrimRange, parse_range};
 use std::error::Error;
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
+use time::OffsetDateTime;
 
 pub fn trim_command(range_str: &str) -> Result<(), Box<dyn Error>> {
     let range = parse_range(range_str)?;
@@ -34,7 +35,11 @@ pub fn trim_command(range_str: &str) -> Result<(), Box<dyn Error>> {
 
         filter_xml_by_time_range(&input, start_threshold, end_threshold)?;
     } else {
-        io::stdout().write_all(&input)?;
+        filter_xml_by_time_range(
+            &input,
+            OffsetDateTime::UNIX_EPOCH,
+            OffsetDateTime::UNIX_EPOCH,
+        )?;
     }
 
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,6 +175,60 @@ fn test_trim_invalid_range_fails() {
 }
 
 #[test]
+fn test_trim_excludes_points_when_no_timestamps_exist() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194"/>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    let output = cmd
+        .arg("trim")
+        .arg("0s,1s")
+        .write_stdin(gpx)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let gpx: gpx::Gpx = gpx::read(output.as_slice()).unwrap();
+    assert_eq!(gpx.tracks[0].segments[0].points.len(), 0);
+}
+
+#[test]
+fn test_trim_excludes_points_when_no_valid_timestamps_exist() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>not-a-time</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    let output = cmd
+        .arg("trim")
+        .arg("0s,1s")
+        .write_stdin(gpx)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let gpx: gpx::Gpx = gpx::read(output.as_slice()).unwrap();
+    assert_eq!(gpx.tracks[0].segments[0].points.len(), 0);
+}
+
+#[test]
 fn test_trim_timestamp_overflow_fails() {
     let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.1" creator="test">


### PR DESCRIPTION
The timestamp-less point exclusion rule should not depend on the file containing at least one other valid timestamp. When there is no valid reference time, `trim` still needs to filter out track points rather than passing the input through unchanged.
