### PR TITLE
fix: require activity track points

### DIFF
--- a/src/commands/trim_to_activity.rs
+++ b/src/commands/trim_to_activity.rs
@@ -1,7 +1,7 @@
 use crate::gpxxml::{extract_track_points, filter_xml_by_time_range_inclusive_end};
 use gpxwrench::detect_activity_bounds;
 use std::error::Error;
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 
 pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(), Box<dyn Error>> {
     let stdin = io::stdin();
@@ -9,11 +9,6 @@ pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(),
     stdin.lock().read_to_end(&mut input)?;
 
     let track_points = extract_track_points(&input)?;
-
-    if track_points.is_empty() {
-        io::stdout().write_all(&input)?;
-        return Ok(());
-    }
 
     let (start_time, end_time) = detect_activity_bounds(&track_points, speed_threshold, buffer)?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -165,6 +165,46 @@ fn test_trim_to_activity_output_is_valid_gpx() {
 }
 
 #[test]
+fn test_trim_to_activity_without_valid_points_fails() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194"/>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    cmd.arg("trim-to-activity")
+        .write_stdin(gpx)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("at least 2 track points"));
+}
+
+#[test]
+fn test_trim_to_activity_without_valid_coordinates_fails() {
+    let gpx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749">
+        <time>2023-01-01T10:00:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    cmd.arg("trim-to-activity")
+        .write_stdin(gpx)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("at least 2 track points"));
+}
+
+#[test]
 fn test_trim_invalid_range_fails() {
     let mut cmd = cargo_bin_cmd!("gpxwrench");
     cmd.arg("trim")


### PR DESCRIPTION
`trim-to-activity` needs valid coordinate/timestamp pairs before it can detect movement. Inputs with no usable points should fail clearly instead of being passed through unchanged.
