### PR TITLE
docs: clarify activity confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Primary user docs and examples live in `README.md`.
 - `trim-to-activity [-s, --speed-threshold <m/s>] [-b, --buffer <seconds>]`
   - Detects the main activity window via speeds between consecutive track points.
   - Internals: `extract_track_points` → `detect_activity_bounds` → `filter_xml_by_time_range_inclusive_end`.
-  - Defaults: speed threshold 1.0 m/s, buffer 30 s; requires at least two timestamped points.
+  - Defaults: speed threshold 1.0 m/s, buffer 30 s; detection requires at least three consecutive speed intervals,
+    which means four points.
 
 ### Key modules and functions
 - `src/lib.rs`

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ cat drive.gpx | cargo run -- trim-to-activity -s 5.0 -b 15 > output.gpx
 
 #### Important Notes
 
-- Requires at least 2 track points with valid coordinates and timestamps
-- Uses conservative detection (requires 3+ consecutive points above threshold)
+- Requires at least 2 track points with valid coordinates and timestamps to run
+- Uses conservative detection to confirm activity (requires 3+ consecutive speed intervals at or above threshold, which means 4 points)
 - Errs on the side of inclusion - better to keep too much than cut off activity
 - Preserves all GPX extensions and formatting like the `trim` command
 


### PR DESCRIPTION
The command can run with two valid points, but confirmed activity needs a longer run: three consecutive speed intervals, or four points. The docs should make that distinction explicit.
