### PR TITLE
fix: validate speed thresholds

### DIFF
--- a/src/commands/trim_to_activity.rs
+++ b/src/commands/trim_to_activity.rs
@@ -4,6 +4,10 @@ use std::error::Error;
 use std::io::{self, Read};
 
 pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(), Box<dyn Error>> {
+    if !speed_threshold.is_finite() || speed_threshold < 0.0 {
+        return Err("Speed threshold must be a finite non-negative number".into());
+    }
+
     let stdin = io::stdin();
     let mut input = Vec::new();
     stdin.lock().read_to_end(&mut input)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -205,6 +205,32 @@ fn test_trim_to_activity_without_valid_coordinates_fails() {
 }
 
 #[test]
+fn test_trim_to_activity_rejects_invalid_speed_thresholds() {
+    for threshold in ["-1.0", "NaN", "inf"] {
+        let mut cmd = cargo_bin_cmd!("gpxwrench");
+        cmd.arg("trim-to-activity")
+            .arg(format!("--speed-threshold={threshold}"))
+            .write_stdin(sample_gpx())
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "Speed threshold must be a finite non-negative number",
+            ));
+    }
+}
+
+#[test]
+fn test_trim_to_activity_accepts_zero_speed_threshold() {
+    let mut cmd = cargo_bin_cmd!("gpxwrench");
+    cmd.arg("trim-to-activity")
+        .arg("--speed-threshold=0.0")
+        .write_stdin(sample_gpx())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<gpx"));
+}
+
+#[test]
 fn test_trim_invalid_range_fails() {
     let mut cmd = cargo_bin_cmd!("gpxwrench");
     cmd.arg("trim")


### PR DESCRIPTION
Activity detection relies on meaningful numeric threshold comparisons. NaN, infinities, and negative values produce surprising classification behavior, so reject them before reading input.
