### PR TITLE
fix: bound GPX input size

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ cat longer-track.gpx | cargo run -- trim 01:02:30,02:15:45 > output.gpx
 - The range is inclusive of the start time and exclusive of the end time `[start, end)`
 - All GPX extensions (including heart rate data) are preserved in the filtered output
 - Track points without timestamps are excluded from the output
+- Input is limited to 100 MiB
 
 ### Trim-to-Activity Command
 
@@ -124,6 +125,7 @@ cat drive.gpx | cargo run -- trim-to-activity -s 5.0 -b 15 > output.gpx
 - Uses conservative detection to confirm activity (requires 3+ consecutive speed intervals at or above threshold, which means 4 points)
 - Errs on the side of inclusion - better to keep too much than cut off activity
 - Preserves all GPX extensions and formatting like the `trim` command
+- Input is limited to 100 MiB and 1,000,000 valid track points
 
 ## Development
 

--- a/src/commands/trim.rs
+++ b/src/commands/trim.rs
@@ -1,15 +1,14 @@
 use crate::gpxxml::{filter_xml_by_time_range, find_minimum_time};
-use gpxwrench::{TrimRange, parse_range};
+use gpxwrench::{MAX_INPUT_BYTES, TrimRange, parse_range, read_to_end_limited};
 use std::error::Error;
-use std::io::{self, Read};
+use std::io;
 use time::OffsetDateTime;
 
 pub fn trim_command(range_str: &str) -> Result<(), Box<dyn Error>> {
     let range = parse_range(range_str)?;
 
     let stdin = io::stdin();
-    let mut input = Vec::new();
-    stdin.lock().read_to_end(&mut input)?;
+    let input = read_to_end_limited(stdin.lock(), MAX_INPUT_BYTES)?;
 
     let min_time = find_minimum_time(&input)?;
 

--- a/src/commands/trim_to_activity.rs
+++ b/src/commands/trim_to_activity.rs
@@ -1,7 +1,7 @@
 use crate::gpxxml::{extract_track_points, filter_xml_by_time_range_inclusive_end};
-use gpxwrench::detect_activity_bounds;
+use gpxwrench::{MAX_INPUT_BYTES, detect_activity_bounds, read_to_end_limited};
 use std::error::Error;
-use std::io::{self, Read};
+use std::io;
 
 pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(), Box<dyn Error>> {
     if !speed_threshold.is_finite() || speed_threshold < 0.0 {
@@ -9,8 +9,7 @@ pub fn trim_to_activity_command(speed_threshold: f64, buffer: u64) -> Result<(),
     }
 
     let stdin = io::stdin();
-    let mut input = Vec::new();
-    stdin.lock().read_to_end(&mut input)?;
+    let input = read_to_end_limited(stdin.lock(), MAX_INPUT_BYTES)?;
 
     let track_points = extract_track_points(&input)?;
 

--- a/src/gpxxml.rs
+++ b/src/gpxxml.rs
@@ -1,4 +1,4 @@
-use gpxwrench::TrackPoint;
+use gpxwrench::{MAX_TRACK_POINTS, TrackPoint};
 use quick_xml::events::Event;
 use quick_xml::{Reader, Writer};
 use std::error::Error;
@@ -265,6 +265,13 @@ fn filter_xml_by_time_to_writer_with_end_mode<W: Write>(
 }
 
 pub fn extract_track_points(input: &[u8]) -> Result<Vec<TrackPoint>, Box<dyn Error>> {
+    extract_track_points_with_limit(input, MAX_TRACK_POINTS)
+}
+
+fn extract_track_points_with_limit(
+    input: &[u8],
+    max_track_points: usize,
+) -> Result<Vec<TrackPoint>, Box<dyn Error>> {
     let mut reader = Reader::from_reader(input);
     let mut buf = Vec::new();
     let mut track_points = Vec::new();
@@ -327,6 +334,12 @@ pub fn extract_track_points(input: &[u8]) -> Result<Vec<TrackPoint>, Box<dyn Err
                     if let (Some(lat), Some(lon), Some(time)) =
                         (current_lat, current_lon, current_time)
                     {
+                        if track_points.len() == max_track_points {
+                            return Err(format!(
+                                "Input exceeds maximum supported track point count of {max_track_points}"
+                            )
+                            .into());
+                        }
                         track_points.push(TrackPoint { lat, lon, time });
                     }
                     in_trkpt = false;
@@ -614,6 +627,49 @@ mod tests {
         assert_eq!(track_points[0].lon, -122.4194);
         assert_eq!(track_points[1].lat, 37.7750);
         assert_eq!(track_points[1].lon, -122.4195);
+    }
+
+    #[test]
+    fn test_extract_track_points_rejects_limit_overflow() {
+        let sample_gpx_with_two_points = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>2023-01-01T10:00:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7750" lon="-122.4195">
+        <time>2023-01-01T10:00:05Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+        let result = extract_track_points_with_limit(sample_gpx_with_two_points.as_bytes(), 1);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_track_points_accepts_exact_limit() {
+        let sample_gpx_with_two_points = r#"<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test">
+  <trk>
+    <trkseg>
+      <trkpt lat="37.7749" lon="-122.4194">
+        <time>2023-01-01T10:00:00Z</time>
+      </trkpt>
+      <trkpt lat="37.7750" lon="-122.4195">
+        <time>2023-01-01T10:00:05Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>"#;
+
+        let track_points =
+            extract_track_points_with_limit(sample_gpx_with_two_points.as_bytes(), 2).unwrap();
+
+        assert_eq!(track_points.len(), 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 use std::error::Error;
+use std::io::Read;
 use time::{Duration, OffsetDateTime};
+
+pub const MAX_INPUT_BYTES: u64 = 100 * 1024 * 1024;
+pub const MAX_TRACK_POINTS: usize = 1_000_000;
 
 #[derive(Debug, Clone)]
 pub struct TrackPoint {
@@ -12,6 +16,21 @@ pub struct TrackPoint {
 pub enum TrimRange {
     Duration { start: Duration, end: Duration },
     Timestamp { start: Duration, end: Duration },
+}
+
+pub fn read_to_end_limited<R: Read>(reader: R, max_bytes: u64) -> Result<Vec<u8>, Box<dyn Error>> {
+    let read_limit = max_bytes
+        .checked_add(1)
+        .ok_or("Maximum input size is too large to enforce")?;
+    let mut input = Vec::new();
+    let mut limited_reader = reader.take(read_limit);
+    limited_reader.read_to_end(&mut input)?;
+
+    if input.len() as u64 > max_bytes {
+        return Err(format!("Input exceeds maximum supported size of {max_bytes} bytes").into());
+    }
+
+    Ok(input)
 }
 
 pub fn parse_duration(s: &str) -> Result<Duration, Box<dyn Error>> {
@@ -204,6 +223,24 @@ mod tests {
             )
             .unwrap(),
         }
+    }
+
+    #[test]
+    fn test_read_to_end_limited_accepts_input_at_limit() {
+        let input = read_to_end_limited("abc".as_bytes(), 3).unwrap();
+        assert_eq!(input, b"abc");
+    }
+
+    #[test]
+    fn test_read_to_end_limited_rejects_input_past_limit() {
+        let result = read_to_end_limited("abcd".as_bytes(), 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_to_end_limited_rejects_unenforceable_limit() {
+        let result = read_to_end_limited("".as_bytes(), u64::MAX);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
The current XML pipeline still reads stdin before processing. Put explicit limits around that read path and the activity track-point accumulator so oversized input fails with a controlled error instead of consuming memory without bound.
