### PR TITLE
refactor: collapse trim range handling

### DIFF
--- a/src/commands/trim.rs
+++ b/src/commands/trim.rs
@@ -13,24 +13,13 @@ pub fn trim_command(range_str: &str) -> Result<(), Box<dyn Error>> {
     let min_time = find_minimum_time(&input)?;
 
     if let Some(min_t) = min_time {
-        let (start_threshold, end_threshold) = match range {
-            TrimRange::Duration { start, end } => (
-                min_t
-                    .checked_add(start)
-                    .ok_or("Trim start exceeds supported timestamp range")?,
-                min_t
-                    .checked_add(end)
-                    .ok_or("Trim end exceeds supported timestamp range")?,
-            ),
-            TrimRange::Timestamp { start, end } => (
-                min_t
-                    .checked_add(start)
-                    .ok_or("Trim start exceeds supported timestamp range")?,
-                min_t
-                    .checked_add(end)
-                    .ok_or("Trim end exceeds supported timestamp range")?,
-            ),
-        };
+        let (TrimRange::Duration { start, end } | TrimRange::Timestamp { start, end }) = range;
+        let start_threshold = min_t
+            .checked_add(start)
+            .ok_or("Trim start exceeds supported timestamp range")?;
+        let end_threshold = min_t
+            .checked_add(end)
+            .ok_or("Trim end exceeds supported timestamp range")?;
 
         filter_xml_by_time_range(&input, start_threshold, end_threshold)?;
     } else {


### PR DESCRIPTION
Duration and timestamp trim ranges have the same representation after parsing. Keeping one threshold calculation avoids duplicated error handling for the two syntaxes.
